### PR TITLE
Add start menu

### DIFF
--- a/Menu.gd
+++ b/Menu.gd
@@ -1,0 +1,26 @@
+extends Control
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready() -> void:
+	$VBoxContainer/StartButton.grab_focus() # So that the player can use keyboard navigation
+	print('ready called')
+	get_tree().paused = true
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta: float) -> void:
+	pass
+
+
+func _on_start_button_button_up() -> void:
+	get_tree().paused = false
+	get_tree().change_scene_to_file("res://main.tscn")
+
+
+func _on_options_button_button_up() -> void:
+	# TODO: Do we need an options button?
+	pass # Replace with function body.
+
+
+func _on_quit_button_button_up() -> void:
+	get_tree().quit()

--- a/main.tscn
+++ b/main.tscn
@@ -28,6 +28,7 @@ sources/2 = SubResource("TileSetAtlasSource_pab8w")
 pattern_0 = SubResource("TileMapPattern_0h1hw")
 
 [node name="main" type="Node2D"]
+process_mode = 1
 script = ExtResource("1_xjsfp")
 
 [node name="PlacementLayer" type="TileMapLayer" parent="."]

--- a/menu.tscn
+++ b/menu.tscn
@@ -1,0 +1,50 @@
+[gd_scene load_steps=3 format=3 uid="uid://bidup656jk0v2"]
+
+[ext_resource type="Script" path="res://Menu.gd" id="1_s7b4p"]
+[ext_resource type="Theme" uid="uid://ca7irp50b1m6f" path="res://Theme.tres" id="2_3ipwx"]
+
+[node name="Menu" type="Control"]
+process_mode = 2
+layout_mode = 3
+anchors_preset = 0
+offset_left = 40.0
+offset_top = 40.0
+offset_right = 40.0
+offset_bottom = 40.0
+script = ExtResource("1_s7b4p")
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+layout_mode = 0
+offset_right = 295.0
+offset_bottom = 205.0
+
+[node name="Title" type="RichTextLabel" parent="VBoxContainer"]
+layout_mode = 2
+theme = ExtResource("2_3ipwx")
+text = "Untitled Game"
+fit_content = true
+autowrap_mode = 0
+
+[node name="StartButton" type="Button" parent="VBoxContainer"]
+layout_mode = 2
+focus_neighbor_top = NodePath("../QuitButton")
+theme = ExtResource("2_3ipwx")
+text = "Start"
+alignment = 0
+
+[node name="OptionsButton" type="Button" parent="VBoxContainer"]
+layout_mode = 2
+theme = ExtResource("2_3ipwx")
+text = "Options"
+alignment = 0
+
+[node name="QuitButton" type="Button" parent="VBoxContainer"]
+layout_mode = 2
+focus_neighbor_bottom = NodePath("../StartButton")
+theme = ExtResource("2_3ipwx")
+text = "Quit"
+alignment = 0
+
+[connection signal="button_up" from="VBoxContainer/StartButton" to="." method="_on_start_button_button_up"]
+[connection signal="button_up" from="VBoxContainer/OptionsButton" to="." method="_on_options_button_button_up"]
+[connection signal="button_up" from="VBoxContainer/QuitButton" to="." method="_on_quit_button_button_up"]

--- a/project.godot
+++ b/project.godot
@@ -10,8 +10,8 @@ config_version=5
 
 [application]
 
-config/name="New Game Project"
-run/main_scene="res://main.tscn"
+config/name="GMTK 2024"
+run/main_scene="res://menu.tscn"
 config/features=PackedStringArray("4.3", "Forward Plus")
 config/icon="res://icon.svg"
 


### PR DESCRIPTION
Add a simple start menu:
![image](https://github.com/user-attachments/assets/8965616e-9b00-44f1-8f76-327d45e00f4a)

Changes:
- set initial scene to show on run to be `menu.tscn`
- set `main.tscn` to be process type `Pausable` (which will also allow us for pausing in the future)
- also added a main theme